### PR TITLE
fix: not intolerant should be not tolerant

### DIFF
--- a/genome_spot/genome_spot.py
+++ b/genome_spot/genome_spot.py
@@ -249,7 +249,7 @@ class GenomeSPOT:
             y_pred = "tolerant"
             error = y_pred_prob
         else:
-            y_pred = "not intolerant"
+            y_pred = "not tolerant"
             error = 1 - y_pred_prob
         return y_pred, error
 


### PR DESCRIPTION
A user [pointed out](https://github.com/cultivarium/GenomeSPOT/issues/6) that the classifications provided were "tolerant" and "not intolerant". The latter was a typo and should have read "not tolerant". This PR corrects that bug. (The bug did not affect any data in the publication or its supplements).