### PR TITLE
Compatibility issues with packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ pip install -r requirements.txt
 Requirements:
 - hmmlearn==0.3.0
 - scikit-learn==1.2.2 (The correct scikit-learn version is **ESSENTIAL** to use models)
-- biopython>=1.81
+- biopython>=1.83
 - numpy>=1.23.5
 - pandas>=1.5.3
 - bacdive>=0.2 (only used in model training)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,14 @@ Reference:
 # Quick start
 ## 1. Install package
 
-Clone the repo, create a virtual environment, then install the package and its requirements:
+Requirements: 
+- **Python version >=3.8.16 and <3.12**
+
+Optional:
+- prodigal ([github.com/hyattpd/Prodigal](https://github.com/hyattpd/Prodigal)) for predicting protein sequences from genomes
+- ncbi-genome-download ([github.com/kblin/ncbi-genome-download](https://github.com/kblin/ncbi-genome-download)) for downloading genomes from GenBank
+
+Install: clone the repo, create a virtual environment, then install the package and its requirements:
 ```shell
 git clone https://github.com/cultivarium/GenomeSPOT.git
 cd GenomeSPOT
@@ -24,7 +31,7 @@ pip install .
 pip install -r requirements.txt
 ```
 
-Requirements:
+Note that the following package versions must be used:
 - hmmlearn==0.3.0
 - scikit-learn==1.2.2 (The correct scikit-learn version is **ESSENTIAL** to use models)
 - biopython>=1.83
@@ -32,9 +39,6 @@ Requirements:
 - pandas>=1.5.3
 - bacdive>=0.2 (only used in model training)
 
-Recommended:
-- ncbi-genome-download ([github.com/kblin/ncbi-genome-download](https://github.com/kblin/ncbi-genome-download)) for downloading genomes from GenBank
-- prodigal ([github.com/hyattpd/Prodigal](https://github.com/hyattpd/Prodigal)) for predicting protein sequences from genomes
 
 ## 2. Run prediction
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ Babel==2.13.1
 bacdive==0.3.1
 backcall==0.2.0
 beautifulsoup4==4.12.2
-biopython==1.81
+biopython>=1.83
 black==23.11.0
 bleach==6.1.0
 certifi==2023.11.17

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ setup(
     package_data={"genome_spot": ["bioinformatics/hmm/hmm_signal_peptide.joblib"]},
     packages=find_packages(exclude=["tests"]),
     scripts=["genome_spot/genome_spot.py"],
-    python_requires=">=3.8.16,<3.12",
     install_requires=[
         "biopython>=1.83",
         "hmmlearn==0.3.0",

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,16 @@
 #!/usr/bin/env python
 
+import sys
+
 from genome_spot._version import __version__
 from setuptools import (
     find_packages,
     setup,
 )
 
+
+if sys.version_info < (3, 8, 16) or sys.version_info >= (3, 12):
+    sys.exit("Python version must be >=3.8.16 and <3.12")
 
 setup(
     name="genome_spot",
@@ -18,7 +23,7 @@ setup(
     package_data={"genome_spot": ["bioinformatics/hmm/hmm_signal_peptide.joblib"]},
     packages=find_packages(exclude=["tests"]),
     scripts=["genome_spot/genome_spot.py"],
-    python_requires=">=3.8.16",
+    python_requires=">=3.8.16,<3.12",
     install_requires=[
         "biopython>=1.83",
         "hmmlearn==0.3.0",


### PR DESCRIPTION
Issue #11 notes that the biopython version requirement was inconsistent across the README, requirements.txt and setup.py. This PR fixes that issue.

Issue #13 notes that python versions >=3.12 have build errors. This PR patches that issue by raising an error if the python version is not within that specified in the README (>=3.8.16 and <3.12).